### PR TITLE
Don't reload graph on each added item

### DIFF
--- a/src/add_equation.py
+++ b/src/add_equation.py
@@ -3,7 +3,7 @@ import logging
 
 from gi.repository import Adw, Gtk
 
-from graphs import calculation, graphs
+from graphs import calculation, graphs, ui
 from graphs.item import Item
 
 
@@ -42,6 +42,8 @@ class AddEquationWindow(Adw.Window):
             if name == "":
                 name = f"Y = {equation}"
             graphs.add_item(parent, Item(parent, xdata, ydata, name))
+            graphs.reload(self)
+            ui.reload_item_menu(self)
             self.destroy()
         except (NameError, SyntaxError) as exception:
             exception_type = exception.__class__.__name__

--- a/src/graphs.py
+++ b/src/graphs.py
@@ -40,6 +40,8 @@ def open_files(self, files, import_settings):
                 toast = "Could not open data, wrong filetype"
                 self.main_window.add_toast(toast)
                 continue
+    ui.reload_item_menu(self)
+    reload(self)
     self.canvas.set_limits()
 
 
@@ -61,8 +63,10 @@ def open_project(self, path):
                     setattr(new_item, attribute, getattr(item, attribute))
             add_item(self, new_item)
             self.datadict_clipboard = self.datadict_clipboard[:-1]
+        ui.reload_item_menu(self)
         ui.enable_data_dependent_buttons(
             self, utilities.get_selected_keys(self))
+        reload(self)
         self.canvas.set_limits()
     except (EOFError, UnpicklingError):
         message = "Could not open project"
@@ -95,10 +99,8 @@ def add_item(self, item):
                 reload(self)
                 return
     self.datadict[key] = item
-    ui.reload_item_menu(self)
     clipboard.add(self)
     self.main_window.item_list.set_visible(True)
-    reload(self)
     ui.enable_data_dependent_buttons(self, True)
 
 

--- a/src/operations.py
+++ b/src/operations.py
@@ -246,5 +246,6 @@ def combine(self):
     # Create the item itself
     new_xdata, new_ydata = sort_data(new_xdata, new_ydata)
     graphs.add_item(self, Item(self, new_xdata, new_ydata, "Combined Data"))
+    graphs.reload(self)
     clipboard.add(self)
     ui.reload_item_menu(self)


### PR DESCRIPTION
Probably my last for the day.

Only reload graph when needed. This prevents the graph from being re-rended 10 times when loading ten different samples. Instead it just reloads the graphs after having added all items.

This should give a significant performance boost when opening a larger amount of data.