### PR TITLE
Add optimize limits option

### DIFF
--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -524,6 +524,7 @@ menu view_menu {
     item (_("Restore View"), "app.restore_view")
     item (_("Previous View"), "app.view_back")
     item (_("Next View"), "app.view_forward")
+    item (_("Optimize Limits"), "app.optimize_limits")
   }
   section {
     submenu {

--- a/src/actions.py
+++ b/src/actions.py
@@ -3,7 +3,7 @@
 import logging
 from gettext import gettext as _
 
-from graphs import clipboard, graphs, operations, ui
+from graphs import clipboard, graphs, operations, plotting_tools, ui
 from graphs.add_equation import AddEquationWindow
 from graphs.export_figure import ExportFigureWindow
 from graphs.misc import InteractionMode
@@ -68,6 +68,11 @@ def undo_action(_action, _target, self):
 
 def redo_action(_action, _target, self):
     clipboard.redo(self)
+
+
+def optimize_limits_action(_action, _target, self):
+    plotting_tools.optimize_limits(self)
+    graphs.refresh(self)
 
 
 def restore_view_action(_action, _target, self):

--- a/src/main.py
+++ b/src/main.py
@@ -60,6 +60,7 @@ class GraphsApplication(Adw.Application):
             ("select_none", ["<primary><shift>A"]),
             ("undo", ["<primary>Z"]),
             ("redo", ["<primary><shift>Z"]),
+            ("optimize_limits", ["<primary>L"]),
             ("restore_view", ["<primary>R"]),
             ("view_back", ["<alt>Z"]),
             ("view_forward", ["<alt><shift>Z"]),


### PR DESCRIPTION
Adds an "optimize limits" option, that resets the limits to the default settings. It's basically a fail-safe if a user has set limits and the data is way out of range, or if the set limits are somehow incorrect (which can happen sometimes).

The idea is to add this still in the 1.6.0 release